### PR TITLE
Fps tracker

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21+build.1
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=0.0.5.1
+mod_version=0.0.5.2
 maven_group=io.github.pikibanana
 archives_base_name=dungeondodgeplus
 

--- a/src/main/java/io/github/pikibanana/Main.java
+++ b/src/main/java/io/github/pikibanana/Main.java
@@ -8,8 +8,9 @@ import io.github.pikibanana.dungeonapi.DungeonDodgeConnection;
 import io.github.pikibanana.dungeonapi.DungeonTracker;
 import io.github.pikibanana.dungeonapi.PlayerStats;
 import io.github.pikibanana.dungeonapi.essence.EssenceCounter;
-import io.github.pikibanana.dungeonapi.essence.EssenceCounterScreen;
+import io.github.pikibanana.hud.DungeonDodgePlusScreen;
 import io.github.pikibanana.dungeonapi.essence.EssenceTracker;
+import io.github.pikibanana.hud.FPSRenderer;
 import io.github.pikibanana.keybinds.QuickWardrobe;
 import io.github.pikibanana.misc.SheepRandomizer;
 import net.fabricmc.api.ModInitializer;
@@ -58,11 +59,12 @@ public class Main implements ModInitializer {
         BlessingFinderData.init();
         ConfigKeybind.register();
         QuickWardrobe.register();
-        EssenceCounterScreen.register();
+        DungeonDodgePlusScreen.register();
         PlayerStats.init();
 
         EssenceCounter essenceCounter = EssenceCounter.getInstance();
         HudRenderCallback.EVENT.register(essenceCounter::render);
+        HudRenderCallback.EVENT.register(FPSRenderer::renderFPS);
 
         SheepRandomizer.registerSheepCommand();
 

--- a/src/main/java/io/github/pikibanana/data/config/DungeonDodgePlusConfig.java
+++ b/src/main/java/io/github/pikibanana/data/config/DungeonDodgePlusConfig.java
@@ -59,6 +59,9 @@ public class DungeonDodgePlusConfig implements ConfigData {
         @ConfigEntry.Gui.CollapsibleObject
         public ShowManaBar showManaBar = new ShowManaBar();
 
+        @ConfigEntry.Gui.CollapsibleObject
+        public ShowFPSCounter showFPSCounter = new ShowFPSCounter();
+
 
         public static class EssenceFinder {
             @ConfigEntry.Gui.Excluded
@@ -173,6 +176,16 @@ public class DungeonDodgePlusConfig implements ConfigData {
             public String label = "Show Mana Bar";
 
             public boolean enabled = true;
+        }
+
+        public static class ShowFPSCounter {
+            @ConfigEntry.Gui.Excluded
+            public String label = "Show FPS Counter";
+
+            @ConfigEntry.ColorPicker
+            public int textColor = 0xFFFFFF;
+
+            public boolean enabled = false;
         }
 
     }

--- a/src/main/java/io/github/pikibanana/hud/FPSRenderer.java
+++ b/src/main/java/io/github/pikibanana/hud/FPSRenderer.java
@@ -1,0 +1,37 @@
+package io.github.pikibanana.hud;
+
+import io.github.pikibanana.data.DungeonData;
+import io.github.pikibanana.data.config.DungeonDodgePlusConfig;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.render.RenderTickCounter;
+
+public class FPSRenderer {
+
+    private static final DungeonData dungeonData = DungeonData.getInstance();
+
+    public static void drawFPS(DrawContext context, TextRenderer renderer, String fpsText, int fpsX, int fpsY, int fpsWidth, int fpsHeight) {
+        int color = DungeonDodgePlusConfig.get().features.showFPSCounter.textColor; //white (default)
+        int bg = 0x66000000; //translucent black
+
+        context.fill(fpsX, fpsY + 1, fpsWidth, fpsHeight - 2, bg);
+        context.drawText(renderer, fpsText, fpsX + 5, fpsY + 5, color, false);
+    }
+
+    public static void renderFPS(DrawContext context, RenderTickCounter tickCounter) {
+        if (DungeonDodgePlusConfig.get().features.showFPSCounter.enabled) {
+
+            TextRenderer renderer = MinecraftClient.getInstance().textRenderer;
+            String fpsText = MinecraftClient.getInstance().getCurrentFps() + " FPS";
+
+            int fpsX = dungeonData.getInt("fpsX", 10);
+            int fpsY = dungeonData.getInt("fpsY", 10);
+            int fpsWidth = fpsX + 10 + renderer.getWidth(fpsText);
+            int fpsHeight = fpsY + 10 + renderer.fontHeight;
+
+            drawFPS(context, renderer, fpsText, fpsX, fpsY, fpsWidth, fpsHeight);
+        }
+    }
+
+}

--- a/src/main/resources/assets/dungeondodgeplus/lang/en_us.json
+++ b/src/main/resources/assets/dungeondodgeplus/lang/en_us.json
@@ -35,13 +35,16 @@
   "text.autoconfig.DungeonDodgePlus.option.features.hideOtherFishingBobbers.enabled": "Hide other player's fishing lines and bobbers.",
   "text.autoconfig.DungeonDodgePlus.option.features.showManaBar": "Mana Bar",
   "text.autoconfig.DungeonDodgePlus.option.features.showManaBar.enabled": "Shows a mana bar with your active mana instead of the hunger bar!",
+  "text.autoconfig.DungeonDodgePlus.option.features.showFPSCounter": "Show FPS Counter",
+  "text.autoconfig.DungeonDodgePlus.option.features.showFPSCounter.enabled": "Shows a tracker that tracks your active FPS!",
+  "text.autoconfig.DungeonDodgePlus.option.features.showFPSCounter.textColor": "FPS Text Color",
 
 
   "text.autoconfig.DungeonDodgePlus.option.features.timestamp.enabled": "Enable Timestamp",
 
   "category.dungeondodgeplus": "DungeonDodge+",
   "key.dungeondodgeplus.config": "Open Config",
-  "key.dungeondodgeplus.essenceScreen": "Edit Essence Counter",
+  "key.dungeondodgeplus.configScreen": "Edit the UI layout for DungeonDodge+",
 
   "category.dungeondodgeplus.wardrobe": "Wardrobe",
   "key.dungeondodgeplus.wardrobe.1": "Equip Slot 1",


### PR DESCRIPTION
Adds a toggleable FPS tracker. Generalizes the screen used to move the essence tracker into a screen utilized to move any custom-HUD elements once they are defined within the screen.

Note: this does not need to be released until v0.0.6 (or may not be needed at all), so you may choose to merge this whenever you wish.