### PR TITLE
Max enchantment glint

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21+build.1
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=0.0.5.2
+mod_version=0.0.5.3
 maven_group=io.github.pikibanana
 archives_base_name=dungeondodgeplus
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21+build.1
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=0.0.5.1
+mod_version=0.0.5.2
 maven_group=io.github.pikibanana
 archives_base_name=dungeondodgeplus
 

--- a/src/main/java/io/github/pikibanana/Main.java
+++ b/src/main/java/io/github/pikibanana/Main.java
@@ -8,8 +8,9 @@ import io.github.pikibanana.dungeonapi.DungeonDodgeConnection;
 import io.github.pikibanana.dungeonapi.DungeonTracker;
 import io.github.pikibanana.dungeonapi.PlayerStats;
 import io.github.pikibanana.dungeonapi.essence.EssenceCounter;
-import io.github.pikibanana.dungeonapi.essence.EssenceCounterScreen;
+import io.github.pikibanana.hud.DungeonDodgePlusScreen;
 import io.github.pikibanana.dungeonapi.essence.EssenceTracker;
+import io.github.pikibanana.hud.FPSRenderer;
 import io.github.pikibanana.keybinds.QuickWardrobe;
 import io.github.pikibanana.misc.SheepRandomizer;
 import net.fabricmc.api.ModInitializer;
@@ -58,11 +59,12 @@ public class Main implements ModInitializer {
         BlessingFinderData.init();
         ConfigKeybind.register();
         QuickWardrobe.register();
-        EssenceCounterScreen.register();
+        DungeonDodgePlusScreen.register();
         PlayerStats.init();
 
         EssenceCounter essenceCounter = EssenceCounter.getInstance();
         HudRenderCallback.EVENT.register(essenceCounter::render);
+        HudRenderCallback.EVENT.register(FPSRenderer::renderFPS);
 
         SheepRandomizer.registerSheepCommand();
 

--- a/src/main/java/io/github/pikibanana/data/EnchantmentUtils.java
+++ b/src/main/java/io/github/pikibanana/data/EnchantmentUtils.java
@@ -1,0 +1,45 @@
+package io.github.pikibanana.data;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DungeonDodge enchantment data.
+ * This should be moved to the API eventually.
+ */
+public class EnchantmentUtils {
+
+    // I need to learn a better way to do this without hard-coding -Wyndev
+    /**
+     * Array of colors that are used to create the max-level enchantment rainbow text.
+     */
+    public static final int[] RAINBOW_GRADIENT = new int[]{
+            0xFF0000, 0xFF001E, 0xFF002B, 0xFF0044, 0xFF0055, 0xFF0066, 0xFF007B, 0xFF0099,
+            0xFF00BB, 0xFF00DD, 0xFF00FF, 0xEA00FF, 0xC800FF, 0xAE00FF, 0x9900FF, 0x8400FF,
+            0x6F00FF, 0x5500FF, 0x4000FF, 0x3300FF, 0x1900FF, 0x0000FF, 0x001AFF, 0x003CFF,
+            0x005EFF, 0x007BFF, 0x0099FF, 0x00B3FF, 0x00D5FF, 0x00F2FF, 0x00FFEA, 0x00FFCC,
+            0x00FFA6, 0x00FF80, 0x00FF5E, 0x00FF2F, 0x00FF11, 0x08FF00, 0x26FF00, 0x44FF00,
+            0x6AFF00, 0x8CFF00, 0xA6FF00, 0xBBFF00, 0xD4FF00, 0xEAFF00, 0xFFFB00, 0xFFE600,
+            0xFFD000, 0xFFBB00, 0xFFA200, 0xFF8400, 0xFF6F00, 0xFF5E00, 0xFF4000, 0xFF2A00,
+            0xFF1E00
+    };
+
+    /**
+     * Map of all max levels corresponding to a list of enchantments that match that max level.
+     * Note that the level keys are Strings corresponding to the roman numeral equivalent of the
+     * max level.
+     * This is currently hard-coded but should be moved to the API eventually.
+     */
+    public static final Map<String, List<String>> MAX_LEVEL_MAP = Map.of(
+            "I", List.of("chicken slayer", "homing", "tough rod", "fish streak", "treasure streak"),
+            "III", List.of("knockback", "depth strider"),
+            "IV", List.of("thunderlord", "fire aspect", "flaming", "flame"),
+            "V", List.of("vampirism", "combo", "jungle protection", "desert protection", "sea creature protection", "vicious"),
+            "VI", List.of("sea strike", "lifesteal", "freezing", "last life", "critical", "blessed strike", "last stand", "prosperity", "turtle overlord", "lure",
+                    "barbed hook", "luck of the sea", "charm", "sharp hook", "blessed hook"),
+            "VII", List.of("sharpness", "smite", "bane of arthropods", "nether slayer", "looting", "sparking", "power", "protection", "projectile protection",
+                    "undead protection", "nether protection", "fortune"),
+            "X", List.of("boss slayer", "mana saver", "infinite quiver", "piercing", "agility", "wisdom", "efficiency")
+    );
+
+}

--- a/src/main/java/io/github/pikibanana/data/config/DungeonDodgePlusConfig.java
+++ b/src/main/java/io/github/pikibanana/data/config/DungeonDodgePlusConfig.java
@@ -62,6 +62,9 @@ public class DungeonDodgePlusConfig implements ConfigData {
         @ConfigEntry.Gui.CollapsibleObject
         public ShowFPSCounter showFPSCounter = new ShowFPSCounter();
 
+        @ConfigEntry.Gui.CollapsibleObject
+        public ColorMaxEnchantments colorMaxEnchantments = new ColorMaxEnchantments();
+
 
         public static class EssenceFinder {
             @ConfigEntry.Gui.Excluded
@@ -182,10 +185,22 @@ public class DungeonDodgePlusConfig implements ConfigData {
             @ConfigEntry.Gui.Excluded
             public String label = "Show FPS Counter";
 
+            public boolean enabled = false;
+
             @ConfigEntry.ColorPicker
             public int textColor = 0xFFFFFF;
+        }
 
-            public boolean enabled = false;
+        public static class ColorMaxEnchantments {
+            @ConfigEntry.Gui.Excluded
+            public String label = "Color Max Enchantments";
+
+            public boolean enabled = true;
+
+            public boolean isRainbow = true;
+
+            @ConfigEntry.ColorPicker
+            public int enchantmentColor = 0xFFD500;
         }
 
     }

--- a/src/main/java/io/github/pikibanana/data/config/DungeonDodgePlusConfig.java
+++ b/src/main/java/io/github/pikibanana/data/config/DungeonDodgePlusConfig.java
@@ -59,6 +59,9 @@ public class DungeonDodgePlusConfig implements ConfigData {
         @ConfigEntry.Gui.CollapsibleObject
         public ShowManaBar showManaBar = new ShowManaBar();
 
+        @ConfigEntry.Gui.CollapsibleObject
+        public ShowFPSCounter showFPSCounter = new ShowFPSCounter();
+
 
         public static class EssenceFinder {
             @ConfigEntry.Gui.Excluded
@@ -173,6 +176,16 @@ public class DungeonDodgePlusConfig implements ConfigData {
             public String label = "Show Mana Bar";
 
             public boolean enabled = true;
+        }
+
+        public static class ShowFPSCounter {
+            @ConfigEntry.Gui.Excluded
+            public String label = "Show FPS Counter";
+
+            @ConfigEntry.ColorPicker
+            public int textColor = 0xFFFFFF;
+
+            public boolean enabled = false;
         }
 
     }

--- a/src/main/java/io/github/pikibanana/hud/FPSRenderer.java
+++ b/src/main/java/io/github/pikibanana/hud/FPSRenderer.java
@@ -1,0 +1,37 @@
+package io.github.pikibanana.hud;
+
+import io.github.pikibanana.data.DungeonData;
+import io.github.pikibanana.data.config.DungeonDodgePlusConfig;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.render.RenderTickCounter;
+
+public class FPSRenderer {
+
+    private static final DungeonData dungeonData = DungeonData.getInstance();
+
+    public static void drawFPS(DrawContext context, TextRenderer renderer, String fpsText, int fpsX, int fpsY, int fpsWidth, int fpsHeight) {
+        int color = DungeonDodgePlusConfig.get().features.showFPSCounter.textColor; //white (default)
+        int bg = 0x66000000; //translucent black
+
+        context.fill(fpsX, fpsY + 1, fpsWidth, fpsHeight - 2, bg);
+        context.drawText(renderer, fpsText, fpsX + 5, fpsY + 5, color, false);
+    }
+
+    public static void renderFPS(DrawContext context, RenderTickCounter tickCounter) {
+        if (DungeonDodgePlusConfig.get().features.showFPSCounter.enabled) {
+
+            TextRenderer renderer = MinecraftClient.getInstance().textRenderer;
+            String fpsText = MinecraftClient.getInstance().getCurrentFps() + " FPS";
+
+            int fpsX = dungeonData.getInt("fpsX", 10);
+            int fpsY = dungeonData.getInt("fpsY", 10);
+            int fpsWidth = fpsX + 10 + renderer.getWidth(fpsText);
+            int fpsHeight = fpsY + 10 + renderer.fontHeight;
+
+            drawFPS(context, renderer, fpsText, fpsX, fpsY, fpsWidth, fpsHeight);
+        }
+    }
+
+}

--- a/src/main/java/io/github/pikibanana/mixin/ItemStackMixin.java
+++ b/src/main/java/io/github/pikibanana/mixin/ItemStackMixin.java
@@ -2,6 +2,7 @@ package io.github.pikibanana.mixin;
 
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import io.github.pikibanana.CustomModelDataFormats;
+import io.github.pikibanana.data.EnchantmentUtils;
 import io.github.pikibanana.data.config.DungeonDodgePlusConfig;
 import net.minecraft.component.Component;
 import net.minecraft.component.ComponentMap;
@@ -9,7 +10,9 @@ import net.minecraft.component.ComponentMapImpl;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.CustomModelDataComponent;
 import net.minecraft.item.ItemStack;
+import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
+import net.minecraft.text.TextColor;
 import net.minecraft.util.Formatting;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -28,6 +31,83 @@ public abstract class ItemStackMixin {
 
     @ModifyReturnValue(method = "getTooltip", at = @At("RETURN"))
     private List<Text> showCustomModelData(List<Text> original) {
+        //color the enchantments in the item lore
+        if (DungeonDodgePlusConfig.get().features.colorMaxEnchantments.enabled) {
+            //the enchantment color of the text to check. This should probably be fetched using the API at some point in case it changes
+            Formatting dungeonDodgeEnchantmentFormatting = Formatting.BLUE;
+            TextColor dungeonDodgeEnchantmentColor = TextColor.fromFormatting(dungeonDodgeEnchantmentFormatting);
+
+            //the max enchantment color
+            int baseColor = DungeonDodgePlusConfig.get().features.colorMaxEnchantments.enchantmentColor;
+            int colorStartIndex = (int)((System.currentTimeMillis() / 50) % EnchantmentUtils.RAINBOW_GRADIENT.length);
+
+            //check all lines in the original lore
+            for (int i = 0; i < original.size(); i++) {
+                //get the original line's value
+                Text text = original.get(i);
+                int rainbowIndex = colorStartIndex;
+
+                //check to see if the original line is the color of the enchantment text
+                if (text.getStyle().getColor() != dungeonDodgeEnchantmentColor) continue;
+                //create the replacement line object
+                MutableText newLine = Text.empty();
+
+                //gets all enchantment texts on this current line
+                String[] enchantments = text.getString().split(",");
+
+                //loops over each enchantment text and applies the correct color code based on if it is maxed
+                int elementNum = 1;
+                for (String enchantment : enchantments) {
+                    //gets the name of the enchantment from the text
+                    String enchantmentName = enchantment.toLowerCase().replaceAll("/[0-9]/g", "");
+
+                    //splits the text into sub-texts by spaces to try and see if the roman numeral at the end is a valid number to check
+                    String[] potentialNumbers = enchantment.toUpperCase().split(" ");
+
+                    //gets the text at the end (we can assume this is the roman numeral)
+                    String potentialNumber = potentialNumbers[potentialNumbers.length - 1];
+
+                    //checks if this roman numeral matches a max level value
+                    boolean hasMatched = false;
+                    if (EnchantmentUtils.MAX_LEVEL_MAP.containsKey(potentialNumber)) {
+                        for (String match : EnchantmentUtils.MAX_LEVEL_MAP.get(potentialNumber)) {
+                            if (enchantmentName.contains(match)) {
+                                hasMatched = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    //checks if this element is the last in the line and the next line is empty
+                    boolean noComma = ((i + 1 < original.size() && original.get(i + 1).getStyle().getColor() != dungeonDodgeEnchantmentColor)
+                                && elementNum++ == enchantments.length);
+
+                    //if the roman numeral matches a max level enchantment, format it accordingly
+                    if (hasMatched) {
+                        if (DungeonDodgePlusConfig.get().features.colorMaxEnchantments.isRainbow) {
+                            MutableText rainbowText = Text.empty();
+
+                            for (char c : enchantment.toCharArray()) {
+                                rainbowIndex = (rainbowIndex + 1 < EnchantmentUtils.RAINBOW_GRADIENT.length ? rainbowIndex + 1 : 0);
+                                int color = EnchantmentUtils.RAINBOW_GRADIENT[rainbowIndex];
+                                rainbowText.append(Text.literal(c + "").setStyle(text.getStyle().withColor(TextColor.fromRgb(color))));
+                            }
+
+                            newLine.append(rainbowText);
+                        } else {
+                            newLine.append(Text.literal(enchantment).setStyle(text.getStyle().withColor(TextColor.fromRgb(baseColor))));
+                        }
+                        if (!noComma) newLine.append(Text.literal(",").formatted(dungeonDodgeEnchantmentFormatting));
+                    } else {
+                        newLine.append(Text.literal(enchantment + (noComma ? "" : ",")).formatted(dungeonDodgeEnchantmentFormatting));
+                    }
+                }
+
+                //update the lore with the new visuals
+                original.set(i, newLine);
+            }
+        }
+        //custom model display on bottom of lore
         if (DungeonDodgePlusConfig.get().features.customModelDataDisplay.enabled) {
             ItemStack itemStack = (ItemStack) (Object) this;
             ComponentMap components = itemStack.getComponents();

--- a/src/main/resources/assets/dungeondodgeplus/lang/en_us.json
+++ b/src/main/resources/assets/dungeondodgeplus/lang/en_us.json
@@ -35,10 +35,13 @@
   "text.autoconfig.DungeonDodgePlus.option.features.hideOtherFishingBobbers.enabled": "Hide other player's fishing lines and bobbers.",
   "text.autoconfig.DungeonDodgePlus.option.features.showManaBar": "Mana Bar",
   "text.autoconfig.DungeonDodgePlus.option.features.showManaBar.enabled": "Shows a mana bar with your active mana instead of the hunger bar!",
-  "text.autoconfig.DungeonDodgePlus.option.features.showFPSCounter": "Show FPS Counter",
-  "text.autoconfig.DungeonDodgePlus.option.features.showFPSCounter.enabled": "Shows a tracker that tracks your active FPS!",
+  "text.autoconfig.DungeonDodgePlus.option.features.showFPSCounter": "Show FPS Tracker",
+  "text.autoconfig.DungeonDodgePlus.option.features.showFPSCounter.enabled": "FPS Tracker Enabled",
   "text.autoconfig.DungeonDodgePlus.option.features.showFPSCounter.textColor": "FPS Text Color",
-
+  "text.autoconfig.DungeonDodgePlus.option.features.colorMaxEnchantments": "Colored Max Level Enchantments",
+  "text.autoconfig.DungeonDodgePlus.option.features.colorMaxEnchantments.enabled": "Colored Max Level Enchantments Enabled",
+  "text.autoconfig.DungeonDodgePlus.option.features.colorMaxEnchantments.isRainbow": "Maximum-level enchantments will appear with a rainbow gradient effect.",
+  "text.autoconfig.DungeonDodgePlus.option.features.colorMaxEnchantments.enchantmentColor": "If the rainbow effect is disabled, maximum-level enchantments will appear with this color.",
 
   "text.autoconfig.DungeonDodgePlus.option.features.timestamp.enabled": "Enable Timestamp",
 

--- a/src/main/resources/assets/dungeondodgeplus/lang/en_us.json
+++ b/src/main/resources/assets/dungeondodgeplus/lang/en_us.json
@@ -35,13 +35,16 @@
   "text.autoconfig.DungeonDodgePlus.option.features.hideOtherFishingBobbers.enabled": "Hide other player's fishing lines and bobbers.",
   "text.autoconfig.DungeonDodgePlus.option.features.showManaBar": "Mana Bar",
   "text.autoconfig.DungeonDodgePlus.option.features.showManaBar.enabled": "Shows a mana bar with your active mana instead of the hunger bar!",
+  "text.autoconfig.DungeonDodgePlus.option.features.showFPSCounter": "Show FPS Counter",
+  "text.autoconfig.DungeonDodgePlus.option.features.showFPSCounter.enabled": "Shows a tracker that tracks your active FPS!",
+  "text.autoconfig.DungeonDodgePlus.option.features.showFPSCounter.textColor": "FPS Text Color",
 
 
   "text.autoconfig.DungeonDodgePlus.option.features.timestamp.enabled": "Enable Timestamp",
 
   "category.dungeondodgeplus": "DungeonDodge+",
   "key.dungeondodgeplus.config": "Open Config",
-  "key.dungeondodgeplus.essenceScreen": "Edit Essence Counter",
+  "key.dungeondodgeplus.configScreen": "Edit the UI layout for DungeonDodge+",
 
   "category.dungeondodgeplus.wardrobe": "Wardrobe",
   "key.dungeondodgeplus.wardrobe.1": "Equip Slot 1",


### PR DESCRIPTION
Adds an option to enable a custom color for max enchantments in an item description. Additionally, this has a rainbow gradient effect as a color option and a static color option. 

Note that this is forked from the `fps-tracker` branch - that branch should be resolved accordingly if this branch is merged first.