### PR TITLE
Fixed comma rendering in enchantment lore

### DIFF
--- a/src/main/java/io/github/pikibanana/mixin/ItemStackMixin.java
+++ b/src/main/java/io/github/pikibanana/mixin/ItemStackMixin.java
@@ -129,29 +129,28 @@ public abstract class ItemStackMixin {
                 for (String enchantment : enchantments) {
                     boolean hasMatched = isHasMatched(enchantment);
 
-                    if (!hasMatched) {
-                        elementNum++;
-                        newLine.append(Text.literal(enchantment).formatted(dungeonDodgeEnchantmentFormatting));
-                        continue;
-                    }
-
                     boolean noComma = ((i + 1 < original.size() && original.get(i + 1).getStyle().getColor() != dungeonDodgeEnchantmentColor)
                             && elementNum++ == enchantments.length);
 
-                    // If it matches a max-level enchantment, apply the rainbow or base color
-                    if (DungeonDodgePlusConfig.get().features.colorMaxEnchantments.isRainbow) {
-                        MutableText rainbowText = Text.empty();
-
-                        for (char c : enchantment.toCharArray()) {
-                            rainbowI = (rainbowI + 1) % rainbowGradient.length;
-                            int color = rainbowGradient[rainbowI];
-                            rainbowText.append(Text.literal(c + "").setStyle(text.getStyle().withColor(TextColor.fromRgb(color))));
-                        }
-
-                        newLine.append(rainbowText);
+                    if (!hasMatched) {
+                        newLine.append(Text.literal(enchantment).formatted(dungeonDodgeEnchantmentFormatting));
                     } else {
-                        newLine.append(Text.literal(enchantment).setStyle(text.getStyle().withColor(TextColor.fromRgb(baseColor))));
+                        // If it matches a max-level enchantment, apply the rainbow or base color
+                        if (DungeonDodgePlusConfig.get().features.colorMaxEnchantments.isRainbow) {
+                            MutableText rainbowText = Text.empty();
+
+                            for (char c : enchantment.toCharArray()) {
+                                rainbowI = (rainbowI + 1) % rainbowGradient.length;
+                                int color = rainbowGradient[rainbowI];
+                                rainbowText.append(Text.literal(c + "").setStyle(text.getStyle().withColor(TextColor.fromRgb(color))));
+                            }
+
+                            newLine.append(rainbowText);
+                        } else {
+                            newLine.append(Text.literal(enchantment).setStyle(text.getStyle().withColor(TextColor.fromRgb(baseColor))));
+                        }
                     }
+
                     if (!noComma) newLine.append(Text.literal(",").formatted(dungeonDodgeEnchantmentFormatting));
                 }
 

--- a/src/main/java/io/github/pikibanana/mixin/ItemStackMixin.java
+++ b/src/main/java/io/github/pikibanana/mixin/ItemStackMixin.java
@@ -40,7 +40,7 @@ public abstract class ItemStackMixin {
         String potentialNumber = enchantmentParts[enchantmentParts.length - 1].toUpperCase();
         int lastSpaceIndex = enchantmentName.lastIndexOf(' ');
         String potentialEnchantmentName = enchantmentName.substring(0, lastSpaceIndex != -1 ? lastSpaceIndex : enchantmentName.length() - 1)
-                .replace(" ", "_").trim();
+                .replace(" ", "_").replaceAll("magic_", "").replaceAll("ranged_", "").trim();
 
         boolean hasMatched = false;
         Map<String, String> maxLevelMap = EnchantmentUtils.getMaxLevelMap();

--- a/src/main/java/io/github/pikibanana/mixin/SkullRenderer.java
+++ b/src/main/java/io/github/pikibanana/mixin/SkullRenderer.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonParser;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
 import com.mojang.authlib.properties.Property;
+import io.github.pikibanana.Main;
 import io.github.pikibanana.data.config.DungeonDodgePlusConfig;
 import io.github.pikibanana.dungeonapi.DungeonTracker;
 import net.fabricmc.api.EnvType;
@@ -110,10 +111,18 @@ public abstract class SkullRenderer {
 
         Property textureProperty = textures.iterator().next();
         String texture = textureProperty.value();
-        JsonObject json = JsonParser.parseString(new String(Base64.getDecoder().decode(texture))).getAsJsonObject();
-        String url = json.getAsJsonObject("textures").getAsJsonObject("SKIN").get("url").getAsString();
+        try {
+            String skullData = new String(Base64.getDecoder().decode(texture));
+            JsonObject json = JsonParser.parseString(skullData).getAsJsonObject();
+            String url = json.getAsJsonObject("textures").getAsJsonObject("SKIN").get("url").getAsString();
 
-        return textureURL.equals(url);
+            return textureURL.equals(url);
+        } catch (IllegalArgumentException e) {
+            //skull is not in Base64 format (I assume this is why I crashed on Hypixel - maybe 1.7.10 Minecraft skull data is formatted in another base?)
+            Main.LOGGER.warn("Skull with data {} is not encoded with Base64 and thus cannot be read properly!", texture);
+            e.printStackTrace();
+            return false;
+        }
     }
 }
 


### PR DESCRIPTION
See title, this patch fixes commas not rendering for non-rainbow enchantments